### PR TITLE
Add clear backtrace on PyO3 error during main.py initialisation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -67,8 +67,7 @@ impl From<PyErr> for Error {
             let traceback_module = py.import("traceback")?;
             let traceback_object = error
                 .traceback(py)
-                .ok_or(pyo3::exceptions::PyWarning::new_err("No traceback found."))
-                .inspect(|r| println!("DEBUG: traceback extracted {:?}", r))?;
+                .ok_or(pyo3::exceptions::PyWarning::new_err("No traceback found."))?;
             let format_traceback = traceback_module.getattr("format_tb")?;
             format_traceback
                 .call1((traceback_object,))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ sys.path = sys.path + [{}]
         code
     );
     py_lib::run_python_internal(path_import, "main.py".into())
-        .unwrap_or_else(|e| panic!("Error '{e}' initializing main.py"));
+        .unwrap_or_else(|e| panic!("Error initializing main.py:\n\n{e}\n"));
 }
 
 /// Initializes the plugin.


### PR DESCRIPTION
Following on from adding some backtrace to the Rustpython initialisation of `main.py` and finding Rustpython lacking a proper trace, I had a go at using PyO3 instead.  To the same end of seeing a traceback, here's some code to print out the trace on error.

# Known Issues
The top level of the stack trace reports: `File "<string>", line 6, in <module>`. I think it's referring to the `main.py` but it's being reported as `"<string>"`; this could be clearer.

# Open Question
How does the code change in the `error.rs` file affect error reporting in other places that might spit out a PyO3 error?  I haven't got my code past the initialisation stage yet.